### PR TITLE
Add fpga-rsu role to install fpga packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,56 @@
-Role Name
+fpga-rsu
 =========
 
-fpga-rsu
+This is a standard Ansible role to install OPAE FPGA packages on hosts.
 
-This is a standard Ansible role, and can be installed as a dependency via ansible-galaxy, pip, or your own mechanism(s).
 
-Consumers of this role (known)
-------------------------------
+How to install
+--------------
 
-Anyone who wants to update FPGA packages on hosts.
+ansible-galaxy install git+https://github.com/redhat-openstack/fpga-rsu.git
+
+
+How to use
+----------
+
+This role can be included in playbooks to use as mentioned in below example.
+
+You should download the OPAE FPGA package tarball from intel portal and set the correct values for role parameters.
+
+
+Role Variables
+--------------
+
+* **fpga_rsu_driver_pkg_url**: Path to the downloaded OPAE FPGA package tarball.
+  Default to ""
+
+* **fpga_rsu_driver_dir**: Directory location where to untar the package.
+  Default to '/usr/share/opae'.
+
+
+Example Playbook
+----------------
+
+Including an example of how to use your role:
+
+```yaml
+- hosts: servers
+  become: true
+  roles:
+     - role: fpga-rsu
+```
 
 How to contribue
 ----------------
 
 Patches should be submitted using git review to the GerritHub.
 
+
 License
 -------
 
 Apache 2.0
+
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for fpga-rsu
+fpga_rsu_driver_dir: '/usr/share/opae'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for fpga-rsu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+

--- a/tasks/install_fpga_packages.yml
+++ b/tasks/install_fpga_packages.yml
@@ -1,0 +1,106 @@
+---
+# Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Fail if fpga_rsu_driver_pkg_url is undefined and empty
+  fail:
+    msg: "fpga_rsu_driver_pkg_url is a mandatory variable"
+  when:
+    - not (( fpga_rsu_driver_pkg_url is defined) and (fpga_rsu_driver_pkg_url | length > 0))
+
+- name: Create fpga driver package directory if not exist
+  file:
+    path: "{{ fpga_rsu_driver_dir }}"
+    state: directory
+    mode: 0755
+
+- name: Download and untar FPGA driver tarball
+  block:
+    - name: Set fact for rpm tarball name
+      set_fact:
+        fpga_rsu_tarball_name: "{{ fpga_rsu_driver_pkg_url | basename }}"
+
+    - name: Download fpga driver tarball
+      copy:
+        src: "{{ fpga_rsu_driver_pkg_url }}"
+        dest: "{{ fpga_rsu_driver_dir }}/{{ fpga_rsu_tarball_name }}"
+      failed_when: false
+
+    - name: untar fpga driver tarball
+      unarchive:
+        src: "{{ fpga_rsu_driver_dir }}/{{ fpga_rsu_tarball_name }}"
+        dest: "{{ fpga_rsu_driver_dir }}"
+      register: fpga_driver_tarball_untar
+      failed_when: false
+
+
+- name: Install packages and verify installation
+  block:
+    - name: setting fact for fpga driver rpm directory
+      set_fact:
+        fpga_driver_rpm_dir: "{{ fpga_rsu_driver_dir }}/{{ fpga_rsu_tarball_name | splitext | first | splitext | first }}"
+
+    - name: Install fpga drivers
+      shell:
+        rpm -ivh *
+      args:
+        chdir: "{{ fpga_driver_rpm_dir }}/opae"
+      register: opae_packages_installed
+
+    - name: Fail when OPAE FPGA package installation failed
+      fail:
+        msg: "OPAE FPGA package installation failed."
+      when: opae_packages_installed.rc != 0
+
+    - name: Verify opae and intel packages installed
+      shell: |-
+        set -o pipefail
+        rpm -qa | grep 'opae\|intel'
+      when: opae_packages_installed.rc == 0
+
+    - name: Verify opae driver installation
+      shell: |-
+        set -o pipefail
+        lsmod | grep fpga
+        lsmod | grep pac_n3000_net
+      register: verify_opae_driver
+
+- name: Verify module is loaded in kernel and update flash
+  block:
+    - name: Verify linux has enumerated Intel FPGA PAC n3000 FPGA management Engine
+      shell: |-
+        set -o pipefail
+        lspci | grep 0b30
+      register: check_linux_enumerated_fpga_mgmt_engine
+
+    - name: Fail if opae driver installation failed
+      fail:
+        msg: >-
+          OPAE driver installation failed. Either module is not loaded in kernel or
+          linux failed to enumerated Intel FPGA PAC n3000 FPGA management Engine.
+      when: verify_opae_driver.rc != 0 or check_linux_enumerated_fpga_mgmt_engine.rc != 0
+
+    - name: Update the flash to remote system update of board
+      shell:
+        fpgaflash user chip_rsu-2x2x25G.bin --rsu
+      args:
+        chdir: "{{ fpga_driver_rpm_dir }}/A10/factory_image"
+      register: fpgaflash_rsu_update
+
+    - name: Fail when Remote system update of board failed
+      fail:
+        msg: Remote system update of board failed using fpgaflash
+      when: fpgaflash_rsu_update.rc != 0
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# # Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# tasks file for fpga-rsu
+- name: check node has accelerator card installed
+  shell: |-
+    set -o pipefail
+    lspci | grep accelerators
+  register: accelerator_card_installed
+
+- name: Install FPGA packages
+  import_role:
+    name: fpga-rsu
+    tasks_from: install_fpga_packages.yml
+  when: accelerator_card_installed.rc == 0
+
+- name: Fail when accelerator card is not installed
+  fail:
+    msg: FPGA hardware accelerator card is not installed.
+  when: accelerator_card_installed.rc != 0

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - fpga-rsu

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# vars file for fpga-rsu
+fpga_rsu_driver_pkg_url: ""


### PR DESCRIPTION
This change adds fpga-rsu ansible-role to install
OPAE FPGA packages on hosts where fpga hardware
is already installed.